### PR TITLE
Fix: Correct PSError import in pdf_parser.py

### DIFF
--- a/pdf_parser.py
+++ b/pdf_parser.py
@@ -9,7 +9,7 @@ from pdfminer.pdfdocument import PDFDocument
 from pdfminer.pdfinterp import PDFResourceManager, PDFPageInterpreter
 from pdfminer.pdfpage import PDFPage
 from pdfminer.pdfparser import PDFParser, PDFSyntaxError # For specific PDF errors
-from pdfminer.psparser import PSError # For PostScript errors, which can occur with PDFs
+from pdfminer.pdftypes import PSError # Corrected import for PSError
 
 def extract_text_from_pdf(pdf_path):
     """


### PR DESCRIPTION
Corrects the import statement for the PSError exception. The exception is now imported from `pdfminer.pdftypes` instead of the incorrect `pdfminer.psparser`.

The PDFSyntaxError import was also verified to be correct. Unit tests were reviewed and required no changes as they correctly reference PSError via the pdf_parser module namespace.